### PR TITLE
Track users on the frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ INSTALLED_APPS = [
 ]
 ```
 
+Then add the following to your URLconf:
+
+```python
+from wagtail_ab_testing import urls as ab_testing_urls
+
+urlpatterns = [
+    ...
+
+    url(r'^abtesting/', include(ab_testing_urls)),
+]
+```
+
+Finally, add the tracking script to your base HTML template:
+
+```django+HTML
+{# Insert this at the top of the template #}
+{% load wagtail_ab_testing_tags %}
+
+...
+
+{# Insert this where you would normally insert a <script> tag #}
+{% wagtail_ab_testing_script %}
+```
+
 ## Goal events
 
 Each A/B test has a goal that is measured after a user visits the page that the A/B test is running on.
@@ -178,29 +202,13 @@ class ContactUsFormPage(AbstractForm):
 
 ## Running A/B tests on a site that uses Cloudflare caching
 
-To run Wagtail A/B testing on a site that uses Cloudflare:
-
-Set the A/B testing mode to "external". This disables Wagtail A/B testing's hooks that will generate unnecessary cookies.
+To run Wagtail A/B testing on a site that uses Cloudflare, firstly generate a secure random string to use as a token, and configure that token in your Django settings file:
 
 ```python
-WAGTAIL_AB_TESTING = {
-    'MODE': 'external',
-}
+WAGTAIL_AB_TESTING_WORKER_TOKEN = '<token here>'
 ```
 
-Next, register the API, the worker will call this to figure out what tests are running.
-
-```python
-from wagtail_ab_testing import api as ab_testing_api
-
-urlpatterns = [
-    ...
-
-    url(r'^abtestingapi/', include(ab_testing_api)),
-]
-```
-
-Finally, set up a Cloudflare Worker based on the following JavaScript. Don't forget to set ``WAGTAIL_DOMAIN`` and ``API_BASE``:
+Then set up a Cloudflare Worker based on the following JavaScript. Don't forget to set ``WAGTAIL_DOMAIN``:
 
 ```javascript
 // Set this to the domain name of your backend server

--- a/wagtail_ab_testing/api.py
+++ b/wagtail_ab_testing/api.py
@@ -62,6 +62,8 @@ class AbTestViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=['get'])
     def serve_variant(self, request, pk=None):
         test = self.get_object()
+        request.wagtail_ab_testing_test = test
+        request.wagtail_ab_testing_serving_variant = True
         return test.variant_revision.as_page_object().serve(request)
 
     @action(detail=True, methods=['post'])

--- a/wagtail_ab_testing/conf.py
+++ b/wagtail_ab_testing/conf.py
@@ -1,7 +1,0 @@
-from django.conf import settings
-
-
-def get_conf():
-    config = getattr(settings, 'WAGTAIL_AB_TESTING', {}).copy()
-    config.setdefault('MODE', 'internal')
-    return config

--- a/wagtail_ab_testing/models.py
+++ b/wagtail_ab_testing/models.py
@@ -134,7 +134,7 @@ class AbTest(models.Model):
         page editor returns to normal.
         """
         if self.status in [AbTest.STATUS_COMPLETED, AbTest.STATUS_CANCELLED]:
-            return reverse('wagtail_ab_testing:results', args=[self.page_id, self.id])
+            return reverse('wagtail_ab_testing_admin:results', args=[self.page_id, self.id])
 
         else:
             return reverse('wagtailadmin_pages:edit', args=[self.page_id])

--- a/wagtail_ab_testing/models.py
+++ b/wagtail_ab_testing/models.py
@@ -203,11 +203,10 @@ class AbTest(models.Model):
         elif action == AbTest.COMPLETION_ACTION_PUBLISH:
             self.variant_revision.publish(user=user)
 
-    def add_participant(self, version=None):
+    def get_participation_numbers(self):
         """
-        Inserts a new participant into the log. Returns the version that they should be shown.
+        Returns a 2-tuple containing the number of participants who were given the control or variant version of the page respectively.
         """
-        # Get current numbers of participants for each version
         stats = self.hourly_logs.aggregate(
             control_participants=Sum('participants', filter=Q(version=self.VERSION_CONTROL)),
             variant_participants=Sum('participants', filter=Q(version=self.VERSION_VARIANT)),
@@ -215,19 +214,41 @@ class AbTest(models.Model):
         control_participants = stats['control_participants'] or 0
         variant_participants = stats['variant_participants'] or 0
 
+        return control_participants, variant_participants
+
+    def get_new_participant_version(self, participation_numbers=None):
+        """
+        Returns the version of the page to display to a new participant.
+        This balances the number of participants between the two variants.
+        """
+        if participation_numbers is None:
+            participation_numbers = self.get_participation_numbers()
+
+        control_participants, variant_participants = participation_numbers
+
+        if variant_participants > control_participants:
+            return self.VERSION_CONTROL
+
+        elif variant_participants < control_participants:
+            return self.VERSION_VARIANT
+
+        else:
+            return random.choice([
+                self.VERSION_CONTROL,
+                self.VERSION_VARIANT,
+            ])
+
+    def add_participant(self, version=None):
+        """
+        Inserts a new participant into the log. Returns the version that they should be shown.
+        """
+        # Get current numbers of participants for each version
+        control_participants, variant_participants = self.get_participation_numbers()
+
         # Create an equal number of participants for each version
         if version is None:
-            if variant_participants > control_participants:
-                version = self.VERSION_CONTROL
-
-            elif variant_participants < control_participants:
-                version = self.VERSION_VARIANT
-
-            else:
-                version = random.choice([
-                    self.VERSION_CONTROL,
-                    self.VERSION_VARIANT,
-                ])
+            # Note, pass participation numbers we already have to save a database query
+            version = self.get_new_participant_version(participation_numbers=(control_participants, variant_participants))
 
         # Add new participant to statistics model
         AbTestHourlyLog._increment_stats(self, version, 1, 0)

--- a/wagtail_ab_testing/static/wagtail_ab_testing/js/tracker.js
+++ b/wagtail_ab_testing/static/wagtail_ab_testing/js/tracker.js
@@ -1,0 +1,127 @@
+(function() {
+    // Check if Do Not Track is enabled
+    if (window.doNotTrack || navigator.doNotTrack || navigator.msDoNotTrack || 'msTrackingProtectionEnabled' in window.external) {
+        if (window.doNotTrack == '1' || navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1' || 'msTrackingProtectionEnabled' in window.external && window.external.msTrackingProtectionEnabled()) {
+            // Don't track this browser
+            return;
+        }
+    }
+
+    function getCookie(cookieName) {
+        var cookies = document.cookie.split(';');
+        for(var i = 0; i < cookies.length; i++) {
+          var cookie = cookies[i];
+          while (cookie.charAt(0) == ' ') {
+            cookie = cookie.substring(1);
+          }
+          if (cookie.indexOf(cookieName + '=') == 0) {
+            return cookie.substring(cookieName.length + 1, cookie.length);
+          }
+        }
+        return '';
+      }
+
+    // Does the current page have an A/B test running?
+    if (window.wagtailAbTesting) {
+        // Register the user as a participant if they haven't registered yet
+        if (window.wagtailAbTesting.testId) {
+            var cookieName = 'abtesting-' + window.wagtailAbTesting.testId + '-version';
+            if (!document.cookie.includes(cookieName)) {
+                fetch(
+                    window.wagtailAbTesting.urls.registerParticipant,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({
+                            test_id: window.wagtailAbTesting.testId,
+                            version: window.wagtailAbTesting.version
+                        })
+                    }
+                ).then(function (response) {
+                    if (response.status === 200) {
+                        // Put the version into a cookie so that Wagtail continues to serve this version
+                        document.cookie = cookieName + ' = ' + window.wagtailAbTesting.version;
+
+                        // Save the goal info into local storage
+                        // This data structure looks like:
+                        // {
+                        //   <id of goal page> : {
+                        //     <goal event>: [<ids of tests with this goal page/event>]
+                        //   }
+                        // }
+                        var goals = window.localStorage.getItem('abtesting-goals');
+                        if (goals) {
+                            goals = JSON.parse(goals);
+                        } else {
+                            goals = {};
+                        }
+
+                        goals[window.wagtailAbTesting.goalPageId] = goals[window.wagtailAbTesting.goalPageId] || {}
+                        goals[window.wagtailAbTesting.goalPageId][window.wagtailAbTesting.goalEvent] = goals[window.wagtailAbTesting.goalPageId][window.wagtailAbTesting.goalEvent] || [];
+                        goals[window.wagtailAbTesting.goalPageId][window.wagtailAbTesting.goalEvent].push(window.wagtailAbTesting.testId);
+
+                        window.localStorage.setItem('abtesting-goals', JSON.stringify(goals));
+                    }
+                });
+            }
+        }
+
+        window.wagtailAbTesting.triggerEvent = function (event) {
+            // Check if any goals were reached
+            var goalsJson = window.localStorage.getItem('abtesting-goals');
+            if (!goalsJson) {
+                return
+            }
+
+            var goals = JSON.parse(goalsJson);
+
+            var checkGoalReached = function (pageId) {
+                var goalsForPage = goals[pageId];
+                if (!goalsForPage) {
+                    return;
+                }
+                var goalsForEvent = goalsForPage[event];
+                if (!goalsForEvent) {
+                    return;
+                }
+
+                goalsForEvent.forEach(function (testId) {
+                    var version = getCookie('abtesting-' + testId + '-version');
+
+                    if (version) {
+                        fetch(
+                            window.wagtailAbTesting.urls.goalReached,
+                            {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json'
+                                },
+                                body: JSON.stringify({
+                                    test_id: testId,
+                                    version: version
+                                })
+                            }
+                        );
+                    }
+                });
+
+                // Remove those goals from local storage so we don't use them again
+                delete goals[pageId][event];
+                window.localStorage.setItem('abtesting-goals', JSON.stringify(goals));
+            };
+
+            // Check goals on current page
+            if (window.wagtailAbTesting.pageId) {
+                checkGoalReached(window.wagtailAbTesting.pageId);
+            }
+
+            // Check non-page-specific goals
+            checkGoalReached(null);
+        };
+
+        // Trigger visit page event
+        window.wagtailAbTesting.triggerEvent('visit-page');
+    }
+})();

--- a/wagtail_ab_testing/templates/wagtail_ab_testing/add_compare.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/add_compare.html
@@ -12,7 +12,7 @@
         {% if differences %}
             {% include "./includes/comparison.html" %}
 
-            <a class="button button-primary" href="{% url 'wagtail_ab_testing:add_ab_test_form' page.id %}">{% trans "Create this test" %}</a>
+            <a class="button button-primary" href="{% url 'wagtail_ab_testing_admin:add_ab_test_form' page.id %}">{% trans "Create this test" %}</a>
         {% else %}
             <div class="help-block help-warning">
                 <p>{% trans "There are no differences, please go back and make some changes to set up a new test" %}

--- a/wagtail_ab_testing/templates/wagtail_ab_testing/add_form.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/add_form.html
@@ -72,7 +72,7 @@
         {% url 'wagtailadmin_home' as wagtailadmin_root_url %}
         wagtailConfig.ADMIN_ROOT_URL = '{{ wagtailadmin_root_url|escapejs }}';
     </script>
-    <script src="{% url 'wagtail_ab_testing:javascript_catalog' %}"></script>
+    <script src="{% url 'wagtail_ab_testing_admin:javascript_catalog' %}"></script>
     <script type="text/javascript" src="{% versioned_static 'wagtailadmin/js/page-chooser-modal.js' %}"></script>
     <script src="{% versioned_static 'wagtail_ab_testing/js/wagtail-ab-testing.js' %}"></script>
 {% endblock %}

--- a/wagtail_ab_testing/templates/wagtail_ab_testing/results.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/results.html
@@ -110,7 +110,7 @@
                 </div>
             </div>
         </div>
-        {% url 'wagtail_ab_testing:compare_draft' page.id as compare_url%}
+        {% url 'wagtail_ab_testing_admin:compare_draft' page.id as compare_url%}
         {% blocktrans with compare_url=compare_url trimmed %}
             <a href="{{ compare_url }}" target="_blank">Compare pages</a> and see how the control and variant pages differ.
         {% endblocktrans %}
@@ -124,7 +124,7 @@
 
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
-    <script src="{% url 'wagtail_ab_testing:javascript_catalog' %}"></script>
+    <script src="{% url 'wagtail_ab_testing_admin:javascript_catalog' %}"></script>
     <script type="text/javascript" src="{% versioned_static 'wagtailadmin/js/page-chooser-modal.js' %}"></script>
     <script src="{% versioned_static 'wagtail_ab_testing/js/wagtail-ab-testing.js' %}"></script>
 {% endblock %}

--- a/wagtail_ab_testing/templates/wagtail_ab_testing/script.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/script.html
@@ -1,0 +1,30 @@
+{% load static %}
+
+{% if track %}
+    <script>
+        window.wagtailAbTesting = {
+            {# Is this a Wagtail Page? #}
+            {# This value is used to check if a goal has been reached #}
+            {% if page %}
+            pageId: {{ page.id }},
+            {% endif %}
+
+            {# Is there a test running on the current page? #}
+            {% if test and version %}
+            testId: {{ test.id }},
+            version: '{{ version|escapejs }}',
+            goalEvent: '{{ test.goal_event|escapejs }}',
+            goalPageId: {% if test.goal_page %}{{ test.goal_page.id }}{% else %}null{% endif %},
+            {% endif %}
+
+            urls: {
+                {% url 'wagtail_ab_testing:register_participant' as register_participant_url %}
+                registerParticipant: '{{ register_participant_url|escapejs }}',
+                {% url 'wagtail_ab_testing:goal_reached' as goal_reached_url %}
+                goalReached: '{{ goal_reached_url|escapejs }}',
+            }
+        };
+    </script>
+
+    <script src="{% static 'wagtail_ab_testing/js/tracker.js' %}" defer async></script>
+{% endif %}

--- a/wagtail_ab_testing/templatetags/wagtail_ab_testing_tags.py
+++ b/wagtail_ab_testing/templatetags/wagtail_ab_testing_tags.py
@@ -1,0 +1,19 @@
+from django import template
+
+from wagtail_ab_testing.models import AbTest
+from wagtail_ab_testing.utils import request_is_trackable
+
+register = template.Library()
+
+
+@register.inclusion_tag('wagtail_ab_testing/script.html', takes_context=True)
+def wagtail_ab_testing_script(context):
+    request = context['request']
+    serving_variant = getattr(request, 'wagtail_ab_testing_serving_variant', False)
+
+    return {
+        'track': request_is_trackable(request),
+        'page': context.get('page', None),
+        'test': getattr(request, 'wagtail_ab_testing_test', None),
+        'version': AbTest.VERSION_VARIANT if serving_variant else AbTest.VERSION_CONTROL,
+    }

--- a/wagtail_ab_testing/test/tests/test_add_abtest.py
+++ b/wagtail_ab_testing/test/tests/test_add_abtest.py
@@ -39,7 +39,7 @@ class TestSaveAndCreateAbTestButton(WagtailTestUtils, TestCase):
             'slug': "test",
             'create-ab-test': '',
         })
-        self.assertRedirects(response, reverse('wagtail_ab_testing:add_ab_test_compare', args=[self.page.id]))
+        self.assertRedirects(response, reverse('wagtail_ab_testing_admin:add_ab_test_compare', args=[self.page.id]))
 
     def test_doesnt_show_on_page_create(self):
         response = self.client.get(reverse('wagtailadmin_pages:add', args=["wagtail_ab_testing_test", "simplepage", self.page.id]))
@@ -126,7 +126,7 @@ class TestAddAbTestCompareView(WagtailTestUtils, TestCase, PermissionTests):
         self.latest_revision = self.page.save_revision()
 
     def get(self, page_id):
-        return self.client.get(reverse('wagtail_ab_testing:add_ab_test_compare', args=[page_id]))
+        return self.client.get(reverse('wagtail_ab_testing_admin:add_ab_test_compare', args=[page_id]))
 
     def test_get_add_compare(self):
         response = self.get(self.page.id)
@@ -152,7 +152,7 @@ class TestAddAbTestFormView(WagtailTestUtils, TestCase, PermissionTests):
         self.latest_revision = self.page.save_revision()
 
     def get(self, page_id):
-        return self.client.get(reverse('wagtail_ab_testing:add_ab_test_form', args=[page_id]))
+        return self.client.get(reverse('wagtail_ab_testing_admin:add_ab_test_form', args=[page_id]))
 
     def test_get_add_form(self):
         response = self.get(self.page.id)
@@ -165,7 +165,7 @@ class TestAddAbTestFormView(WagtailTestUtils, TestCase, PermissionTests):
         })
 
     def test_post_add_form(self):
-        response = self.client.post(reverse('wagtail_ab_testing:add_ab_test_form', args=[self.page.id]), {
+        response = self.client.post(reverse('wagtail_ab_testing_admin:add_ab_test_form', args=[self.page.id]), {
             'name': 'Test',
             'hypothesis': 'Does changing the title to "Donate now!" increase donations?',
             'goal_event': 'visit-page',
@@ -186,7 +186,7 @@ class TestAddAbTestFormView(WagtailTestUtils, TestCase, PermissionTests):
         self.assertEqual(ab_test.status, AbTest.STATUS_DRAFT)
 
     def test_post_add_form_start(self):
-        response = self.client.post(reverse('wagtail_ab_testing:add_ab_test_form', args=[self.page.id]), {
+        response = self.client.post(reverse('wagtail_ab_testing_admin:add_ab_test_form', args=[self.page.id]), {
             'name': 'Test',
             'hypothesis': 'Does changing the title to "Donate now!" increase donations?',
             'goal_event': 'visit-page',
@@ -202,7 +202,7 @@ class TestAddAbTestFormView(WagtailTestUtils, TestCase, PermissionTests):
     def test_post_add_form_start_without_publish_permission(self):
         self.moderators_group.page_permissions.filter(permission_type='publish').delete()
 
-        response = self.client.post(reverse('wagtail_ab_testing:add_ab_test_form', args=[self.page.id]), {
+        response = self.client.post(reverse('wagtail_ab_testing_admin:add_ab_test_form', args=[self.page.id]), {
             'name': 'Test',
             'hypothesis': 'Does changing the title to "Donate now!" increase donations?',
             'goal_event': 'visit-page',

--- a/wagtail_ab_testing/test/tests/test_compare_draft.py
+++ b/wagtail_ab_testing/test/tests/test_compare_draft.py
@@ -25,6 +25,6 @@ class TestCompareDraftView(WagtailTestUtils, TestCase):
         )
 
     def test_get_compare_draft(self):
-        response = self.client.get(reverse('wagtail_ab_testing:compare_draft', args=[self.page.id]))
+        response = self.client.get(reverse('wagtail_ab_testing_admin:compare_draft', args=[self.page.id]))
 
         self.assertTemplateUsed(response, "wagtail_ab_testing/compare.html")

--- a/wagtail_ab_testing/test/tests/test_report.py
+++ b/wagtail_ab_testing/test/tests/test_report.py
@@ -35,6 +35,6 @@ class TestReportView(WagtailTestUtils, TestCase):
         )
 
     def test_get_report(self):
-        response = self.client.get(reverse('wagtail_ab_testing:report'))
+        response = self.client.get(reverse('wagtail_ab_testing_admin:report'))
 
         self.assertTemplateUsed(response, "wagtail_ab_testing/report.html")

--- a/wagtail_ab_testing/test/tests/test_results.py
+++ b/wagtail_ab_testing/test/tests/test_results.py
@@ -35,6 +35,6 @@ class TestResultsView(WagtailTestUtils, TestCase):
         )
 
     def test_get_results(self):
-        response = self.client.get(reverse('wagtail_ab_testing:results', args=[self.page.id, self.ab_test.id]))
+        response = self.client.get(reverse('wagtail_ab_testing_admin:results', args=[self.page.id, self.ab_test.id]))
 
         self.assertTemplateUsed(response, "wagtail_ab_testing/results.html")

--- a/wagtail_ab_testing/test/tests/test_views.py
+++ b/wagtail_ab_testing/test/tests/test_views.py
@@ -1,0 +1,148 @@
+import datetime
+
+from django.urls import reverse
+from freezegun import freeze_time
+from rest_framework.test import APITestCase
+from wagtail.core.models import Page
+
+from wagtail_ab_testing.models import AbTest
+
+
+@freeze_time('2020-11-04T22:37:00Z')
+class TestRegisterParticipant(APITestCase):
+    def setUp(self):
+        # Create test page with a draft revision
+        self.page = Page.objects.get(id=2).add_child(instance=Page(title="Test", slug="test"))
+        self.page.title = "Changed title"
+        self.page.save_revision()
+
+        # Create an A/B test
+        self.ab_test = AbTest.objects.create(
+            page=self.page,
+            name="Test",
+            variant_revision=self.page.get_latest_revision(),
+            status=AbTest.STATUS_RUNNING,
+            goal_page_id=2,
+            goal_event='visit-page',
+            sample_size=100,
+        )
+
+    def test_register_participant(self):
+        # Add a participant for variant
+        # This will make the new participant use control
+        self.ab_test.add_participant(AbTest.VERSION_VARIANT)
+
+        response = self.client.post(
+            reverse('wagtail_ab_testing:register_participant'),
+            {
+                'test_id': self.ab_test.id,
+                'version': 'control',
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # This should've created a history log
+        log = self.ab_test.hourly_logs.order_by('id').last()
+
+        self.assertEqual(log.date, datetime.date(2020, 11, 4))
+        self.assertEqual(log.hour, 22)
+        self.assertEqual(log.version, AbTest.VERSION_CONTROL)
+        self.assertEqual(log.participants, 1)
+        self.assertEqual(log.conversions, 0)
+
+    def test_register_participant_finish(self):
+        # Add a participant for variant
+        # This will make the new participant use control
+        self.ab_test.add_participant(AbTest.VERSION_VARIANT)
+
+        # Lower sample size to two so the ab test finishes on this request
+        self.ab_test.sample_size = 2
+        self.ab_test.save()
+
+        response = self.client.post(
+            reverse('wagtail_ab_testing:register_participant'),
+            {
+                'test_id': self.ab_test.id,
+                'version': 'control',
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.ab_test.refresh_from_db()
+        self.assertEqual(self.ab_test.status, AbTest.STATUS_FINISHED)
+
+
+@freeze_time('2020-11-04T22:37:00Z')
+class TestGoalReached(APITestCase):
+    def setUp(self):
+        # Create test page with a draft revision
+        self.page = Page.objects.get(id=2).add_child(instance=Page(title="Test", slug="test"))
+        self.page.title = "Changed title"
+        self.page.save_revision()
+
+        # Create an A/B test
+        self.ab_test = AbTest.objects.create(
+            page=self.page,
+            name="Test",
+            variant_revision=self.page.get_latest_revision(),
+            status=AbTest.STATUS_RUNNING,
+            goal_page_id=2,
+            goal_event='visit-page',
+            sample_size=100,
+        )
+
+    def test_log_conversion_for_control(self):
+        response = self.client.post(
+            reverse('wagtail_ab_testing:goal_reached', args=[]),
+            {
+                'test_id': self.ab_test.id,
+                'version': 'control'
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # This should've created a history log
+        log = self.ab_test.hourly_logs.get()
+
+        self.assertEqual(log.date, datetime.date(2020, 11, 4))
+        self.assertEqual(log.hour, 22)
+        self.assertEqual(log.version, AbTest.VERSION_CONTROL)
+        self.assertEqual(log.participants, 0)
+        self.assertEqual(log.conversions, 1)
+
+    def test_log_conversion_for_variant(self):
+        response = self.client.post(
+            reverse('wagtail_ab_testing:goal_reached', args=[]),
+            {
+                'test_id': self.ab_test.id,
+                'version': 'variant'
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # This should've created a history log
+        log = self.ab_test.hourly_logs.get()
+
+        self.assertEqual(log.date, datetime.date(2020, 11, 4))
+        self.assertEqual(log.hour, 22)
+        self.assertEqual(log.version, AbTest.VERSION_VARIANT)
+        self.assertEqual(log.participants, 0)
+        self.assertEqual(log.conversions, 1)
+
+    def test_log_conversion_for_something_else(self):
+        response = self.client.post(
+            reverse('wagtail_ab_testing:goal_reached', args=[]),
+            {
+                'test_id': self.ab_test.id,
+                'version': 'something-else'
+            }
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        # This shouldn't create a history log
+        self.assertFalse(self.ab_test.hourly_logs.exists())

--- a/wagtail_ab_testing/test/urls.py
+++ b/wagtail_ab_testing/test/urls.py
@@ -6,6 +6,7 @@ from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.core import urls as wagtail_urls
 
 from wagtail_ab_testing import api as ab_testing_api
+from wagtail_ab_testing import urls as ab_testing_urls
 
 
 urlpatterns = [
@@ -13,5 +14,7 @@ urlpatterns = [
     url(r"^admin/", include(wagtailadmin_urls)),
     url(r"^documents/", include(wagtaildocs_urls)),
     url(r'^abtestingapi/', include(ab_testing_api, namespace='ab_testing_api')),
+    url(r'^abtesting/', include(ab_testing_urls, namespace='wagtail_ab_testing')),
+
     url(r"", include(wagtail_urls)),
 ]

--- a/wagtail_ab_testing/urls.py
+++ b/wagtail_ab_testing/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+app_name = 'wagtail_ab_testing'
+urlpatterns = [
+    path('register-participant/', views.register_participant, name='register_participant'),
+    path('goal-reached/', views.goal_reached, name='goal_reached'),
+]

--- a/wagtail_ab_testing/wagtail_hooks.py
+++ b/wagtail_ab_testing/wagtail_hooks.py
@@ -34,8 +34,8 @@ def register_admin_urls():
         path(
             "abtests/",
             include(
-                (urls, "wagtail_ab_testing"),
-                namespace="wagtail_ab_testing",
+                (urls, "wagtail_ab_testing_admin"),
+                namespace="wagtail_ab_testing_admin",
             ),
         )
     ]
@@ -68,7 +68,7 @@ class AbTestingTabActionMenuItem(ActionMenuItem):
         if 'page' in context:
             return format_html(
                 '<script src="{}"></script><script src="{}"></script><script>window.abTestingTabProps = JSON.parse("{}");</script>',
-                reverse('wagtail_ab_testing:javascript_catalog'),
+                reverse('wagtail_ab_testing_admin:javascript_catalog'),
                 versioned_static('wagtail_ab_testing/js/wagtail-ab-testing.js'),
                 escapejs(json.dumps({
                     'tests': [
@@ -77,7 +77,7 @@ class AbTestingTabActionMenuItem(ActionMenuItem):
                             'name': ab_test.name,
                             'started_at': ab_test.first_started_at.strftime(DATE_FORMAT) if ab_test.first_started_at else _("Not started"),
                             'status': ab_test.get_status_description(),
-                            'results_url': reverse('wagtail_ab_testing:results', args=[ab_test.page_id, ab_test.id]),
+                            'results_url': reverse('wagtail_ab_testing_admin:results', args=[ab_test.page_id, ab_test.id]),
                         }
                         for ab_test in AbTest.objects.filter(page=context['page']).order_by('-id')
                     ],
@@ -96,7 +96,7 @@ def register_ab_testing_tab_action_menu_item():
 @hooks.register('after_edit_page')
 def redirect_to_create_ab_test(request, page):
     if 'create-ab-test' in request.POST:
-        return redirect('wagtail_ab_testing:add_ab_test_compare', page.id)
+        return redirect('wagtail_ab_testing_admin:add_ab_test_compare', page.id)
 
 
 @hooks.register('before_edit_page')
@@ -154,7 +154,7 @@ class AbTestingReportMenuItem(MenuItem):
 
 @hooks.register('register_reports_menu_item')
 def register_ab_testing_report_menu_item():
-    return AbTestingReportMenuItem(_('A/B testing'), reverse('wagtail_ab_testing:report'), icon_name='people-arrows', order=1000)
+    return AbTestingReportMenuItem(_('A/B testing'), reverse('wagtail_ab_testing_admin:report'), icon_name='people-arrows', order=1000)
 
 
 @hooks.register('register_icons')


### PR DESCRIPTION
This PR adds a script for tracking users using cookies/local storage and an API for them to submit their tracking results.