### PR TITLE
Cookie expiry

### DIFF
--- a/wagtail_ab_testing/static/wagtail_ab_testing/js/tracker.js
+++ b/wagtail_ab_testing/static/wagtail_ab_testing/js/tracker.js
@@ -42,7 +42,9 @@
                 ).then(function (response) {
                     if (response.status === 200) {
                         // Put the version into a cookie so that Wagtail continues to serve this version
-                        document.cookie = cookieName + ' = ' + window.wagtailAbTesting.version;
+                        var expires = new Date();
+                        expires.setFullYear(expires.getFullYear() + 1);
+                        document.cookie = cookieName + '=' + window.wagtailAbTesting.version + '; expires=' + expires.toUTCString();
 
                         // Save the goal info into local storage
                         // This data structure looks like:


### PR DESCRIPTION
This PR fixes a couple of issues

- There wasn't a cookie expiry, so the cookie would delete itself whenever the user restarts their browser
- If the cookie was deleted/expired, it would append the goal again to the ``abtesting-goals`` in local storage, which led to it calling the "goal reached" API multiple times when the user reached the goal page and they would be counted multiple times