### PR TITLE
Add default_auto_field to app config

### DIFF
--- a/wagtail_ab_testing/apps.py
+++ b/wagtail_ab_testing/apps.py
@@ -5,3 +5,4 @@ class WagtailAbTestingAppConfig(AppConfig):
     label = "wagtail_ab_testing"
     name = "wagtail_ab_testing"
     verbose_name = "A/B Testing"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
Fixes the `(models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.` warning in Django 3.2