### PR TITLE
Support Wagtail 2.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     install_requires=[
         "Django>=2.2,<3.3",
-        "Wagtail>=2.11,<2.16",
+        "Wagtail>=2.11,<2.17",
         "user-agents>=2.2,<2.3",
         "numpy>=1.19.4,<1.20",
         "scipy>=1.5.4,<1.6",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{37,38,39}-dj{22,30,32,master}-wa{211,215,main}-{sqlite,postgres}
+envlist = py{37,38,39}-dj{22,30,32,main}-wa{211,215,216,main}-{sqlite,postgres}
 
 [flake8]
 # E501: Line too long
@@ -28,6 +28,7 @@ deps =
 
     wa211: wagtail>=2.11,<2.12
     wa215: wagtail>=2.15rc1,<2.16
+    wa216: wagtail>=2.16.1,<2.17
     wamain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2==2.8.6


### PR DESCRIPTION
Currently preventing wagtail.io from being updated to 2.16.1. 

- update tox.ini to reflect the new wagtail release 2.16.1. 
- I think  dj{22,30,32,`master`} should be dj{22,30,32,`main`}, because there's no djmaster defined in the tox.ini