### PR TITLE
Upgrade numpy from 1.19.5 to 1.22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "Django>=2.2,<3.3",
         "Wagtail>=2.11,<2.16",
         "user-agents>=2.2,<2.3",
-        "numpy>=1.19.4,<1.20",
+        "numpy>=1.22.0,<1.22.1",
         "scipy>=1.5.4,<1.6",
     ],
     extras_require={


### PR DESCRIPTION
Safety Check
+============================+===========+==========================+==========+
| package | installed | affected | ID |
+============================+===========+==========================+==========+
| numpy | 1.19.5 | <1.21.0 | 43453 |
| numpy | 1.19.5 | <1.22.0 | 44716 |
| numpy | 1.19.5 | <1.22.0 | 44717 |
| numpy | 1.19.5 | >0 | 44715 |
+==============================================================================+

1.19.5 apparently have some vulnerabilities 
